### PR TITLE
fix config writing issue

### DIFF
--- a/pylhc_submitter/autosix.py
+++ b/pylhc_submitter/autosix.py
@@ -275,7 +275,7 @@ def main(opt):
     with open(opt.mask, "r") as mask_f:
         mask = mask_f.read()
     opt = _check_opts(mask, opt)
-    save_config(opt.working_directory, opt, __file__)
+    save_config(opt.working_directory, opt, "autosix")
 
     jobdf = _generate_jobs(opt.working_directory, opt.jobid_mask, **opt.replace_dict)
     for job_args in jobdf.iterrows():

--- a/pylhc_submitter/job_submitter.py
+++ b/pylhc_submitter/job_submitter.py
@@ -278,7 +278,7 @@ def main(opt):
         LOG.info("Starting Job-submitter.")
 
     opt = _check_opts(opt)
-    save_config(opt.working_directory, opt, __file__)
+    save_config(opt.working_directory, opt, "job_submitter")
 
     job_df = _create_jobs(
         opt.working_directory,


### PR DESCRIPTION
Fixes #15 

instead of using `__file__`, the name of the script is now specified.
The former has led to some errors as the full path of the file was given and the `config.ini` was saved there then instead of the `working_directory`.