### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ It runs on `ubuntu-latest` and our lowest supported Python version, `Python 3.7`
 ### Testing Suite
 
 Tests are ensured in the `tests` workflow, which triggers on all pushes.
-It runs on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.7`, `3.8` and `3.9`).
+It runs on a matrix of all supported operating systems (ubuntu-18.04, ubuntu-20.04, windows-latest and macos-latest) for all supported Python versions (currently `3.7`, `3.8`, `3.9` and `3.10`).
 
 ### Test Coverage
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.x]  # crons should always run latest python hence 3.x
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.x]  # crons should always run latest python hence 3.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        # Make sure to escape 3.10 with quotes so it doesn't get interpreted as float 3.1 by GA's parser
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     packages=setuptools.find_packages(exclude=["tests*", "doc"]),
     include_package_data=True,


### PR DESCRIPTION
This series of PRs (see other repos):

- Removes Python `3.6` from our CI setups as it has reached EOL
- Adds Python `3.10`
- Updates CI readmes
- Updates classifiers

I have changed the `exclude` section, considering `pytables` is fine building on `3.9` and `3.10` now. Hoewever it seems `jpype1` is failing builds on `3.10`, only on `windows-latest` so that is excluded from the build.