### PR TITLE
Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `pylhc-submitter` Changelog
 
+## Version 2.0.6
+
+- Dropped support for `Python 3.9`.
+
 ## Version 2.0.5
 
 - Implemented compatibility with the recently released `htcondor 25.0` which brought breaking changes.

--- a/pylhc_submitter/__init__.py
+++ b/pylhc_submitter/__init__.py
@@ -11,7 +11,7 @@ pylhc-submitter contains scripts to simplify the creation and submission of jobs
 __title__ = "pylhc_submitter"
 __description__ = "pylhc-submitter contains scripts to simplify the creation and submission of jobs to HTCondor at CERN"
 __url__ = "https://github.com/pylhc/submitter"
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ authors = [
 ]
 license = "MIT"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 classifiers = [
     "Intended Audience :: Science/Research",
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
Drop Python 3.9, add coverage config options (as done in `omc3`), remove CodeClimate and update coverage badge on readme, some markdown linting.

Tests also good on 3.14 on macOS.